### PR TITLE
Fix MID-4683 - Google Apps Connector issue with Midpoint 3.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
     <parent>
         <artifactId>connector-parent</artifactId>
         <groupId>com.evolveum.polygon</groupId>
-        <version>1.4.2.14</version>
+        <version>1.4.3.11</version>
         <relativePath></relativePath>
     </parent>
 
     <groupId>com.evolveum.polygon</groupId>
     <artifactId>connector-googleapps</artifactId>
-    <version>1.4.2.18-SNAPSHOT</version>
+    <version>1.4.2.19-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GoogleApps Connector</name>

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
@@ -38,7 +38,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.identityconnectors.common.Assertions;
 import org.identityconnectors.common.CollectionUtil;
-import org.identityconnectors.common.IOUtil;
 import org.identityconnectors.common.StringUtil;
 import org.identityconnectors.common.logging.Log;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
@@ -1261,7 +1260,7 @@ public class GoogleAppsConnector implements Connector, CreateOp, DeleteOp, Schem
                     attributes.add(attribute);
                 }
             }
-            return IOUtil.join(attributes, COMMA);
+            return StringUtil.join(attributes, COMMA);
         }
         return null;
     }


### PR DESCRIPTION
The cause is that Midpoint 3.8 is using ConnId framework version 1.4.3.11 and in this version a method has been moved from a class to another.
Method: join()
From class: IOUtil    ( IOUtil.join() )
To class: StringUtil  ( StringUtil.join )
However I had a hard time trying to compile this connector becase the version of 'com.evolveum.polygon.connector-parent.jar', 
If someone could advice here it would be appreciated.
If I set the version in pom.xml to 1.4.3.41  maven is able to download the jar, but then Midpoint will not instantiate the connector because this version is higher than its connif framework, 
If I set the version in pom to match midpoint connif framework version (1.4.3.11) then maven cannot find the connector-parent jar.