### PR TITLE
Fixed deprecated call to StringUtils.join and connector-parent broken…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,13 +31,13 @@
     <parent>
         <artifactId>connector-parent</artifactId>
         <groupId>com.evolveum.polygon</groupId>
-        <version>1.4.3.11</version>
+        <version>1.4.2.18</version>
         <relativePath></relativePath>
     </parent>
 
     <groupId>com.evolveum.polygon</groupId>
     <artifactId>connector-googleapps</artifactId>
-    <version>1.4.2.19-SNAPSHOT</version>
+    <version>1.4.2.20-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GoogleApps Connector</name>

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
@@ -1260,7 +1260,7 @@ public class GoogleAppsConnector implements Connector, CreateOp, DeleteOp, Schem
                     attributes.add(attribute);
                 }
             }
-            return StringUtil.join(attributes, COMMA);
+            return String.join(String.valueOf(COMMA), attributes);
         }
         return null;
     }


### PR DESCRIPTION
The fix merged from @alexandrezia is no longer working. The references to the connector-parent 1.4.3.* fails with this error:

[FATAL] Non-resolvable parent POM for com.evolveum.polygon:connector-googleapps:1.4.2.20-SNAPSHOT: Could not transfer artifact com.evolveum.polygon:connector-parent:pom:1.4.3.47 from/to evolveum-nexus-releases (http://nexus.evolveum.com/nexus/content/repositories/releases/): Access denied to: http://nexus.evolveum.com/nexus/content/repositories/releases/com/evolveum/polygon/connector-parent/1.4.3.47/connector-parent-1.4.3.47.pom and 'parent.relativePath' points at no local POM @ line 31, column 13
 @ 

I also tried with version 1.4.3.41 (listed [here](https://nexus.evolveum.com/nexus/#browse/browse:connectors:com%2Fevolveum%2Fpolygon%2Fconnector-parent))

