### PR TITLE
Allow members attribute with null value to remove all group members

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
@@ -1478,10 +1478,11 @@ public class GoogleAppsConnector implements Connector, CreateOp, DeleteOp, Schem
                         });
             }
             Attribute members = attributesAccessor.find(MEMBERS_ATTR);
-            if (null != members && null != members.getValue()) {
+            if (null != members) {
                 final Directory.Members service = configuration.getDirectory().members();
-                if (members.getValue().isEmpty()) {
+                if (null == members.getValue() || members.getValue().isEmpty()) {
                     // Remove all membership
+                    logger.info("Null or empty membership, so removing all members from: " + uid.getUidValue());
                     for (String member : listMembers(service, uidAfterUpdate.getUidValue(), null)) {
 
                         execute(deleteMembers(service, uidAfterUpdate.getUidValue(), member),


### PR DESCRIPTION
When the members attribute itself is defined, but its value was null, the connector would skip removing the members and return success. This change removes all of the members from the group in this circumstance, treating the value being null similarly to the value being "".