### PR TITLE
Changes to schema to support group management

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GroupHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GroupHandler.java
@@ -51,6 +51,7 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
     private static final Log logger = Log.getLog(GroupHandler.class);
 
     public Void visitAndFilter(Directory.Groups.List list, AndFilter andFilter) {
+            logger.warn("Throwing get exception in visitAndFilter");
         throw getException();
     }
 
@@ -58,6 +59,7 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
         if (containsFilter.getAttribute().is(MEMBERS_ATTR)) {
             list.setUserKey(containsFilter.getValue());
         } else {
+            logger.warn("Throwing get exception in visitContainsFilter");
             throw getException();
         }
         return null;
@@ -66,6 +68,7 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
     public Void visitContainsAllValuesFilter(Directory.Groups.List list,
             ContainsAllValuesFilter containsAllValuesFilter) {
         //TODO needed for removing deleted users from groups
+            logger.warn("Throwing get exception in visitContainsAllValuesFilter");
         throw getException();
     }
 
@@ -199,7 +202,7 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
 
         // Virtual Attribute
         builder.addAttributeInfo(AttributeInfoBuilder.define(MEMBERS_ATTR).setMultiValued(true)
-                .setReturnedByDefault(false).build());
+                .setReturnedByDefault(true).build());
 
         return builder.build();
     }

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/UserHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/UserHandler.java
@@ -40,10 +40,12 @@ import org.identityconnectors.framework.common.exceptions.ConnectorException;
 import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.*;
 import org.identityconnectors.framework.common.objects.filter.*;
+import org.identityconnectors.framework.common.objects.AttributeInfo.Flags;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
+import java.util.EnumSet;
 
 import static com.evolveum.polygon.connector.googleapps.GoogleAppsConnector.ID_ATTR;
 import static com.evolveum.polygon.connector.googleapps.GoogleAppsConnector.PHOTO_ATTR;
@@ -497,7 +499,21 @@ public class UserHandler implements FilterVisitor<StringBuilder, Directory.Users
         builder.addAttributeInfo(AttributeInfoBuilder.define(PHOTO_ATTR, byte[].class)
                 .setReturnedByDefault(false).build());
 
-        builder.addAttributeInfo(PredefinedAttributeInfos.GROUPS);
+        /* 
+        builder.addAttributeInfo(PredefinedAttributeInfos.GROUPS.setReturnedByDefault(true));
+        AttributeInfoBuilder subjectId = new AttributeInfoBuilder();
+        subjectId.setName("subjectId");
+        subjectId.setNativeName("subject-id");
+        subjectId.setCreateable(true);
+        subjectId.setUpdateable(true);
+        subjectId.setReadable(true);
+        subjectId.setRequired(false);
+        subjectId.setMultiValued(false);
+        attributes.add(subjectId.build());
+        builder.addAttributeInfo(AttributeInfoBuilder.define("groups").setNativeName("__GROUPS__").setMultiValued(true).setReturnedByDefault(true).build());
+        */
+        AttributeInfo GROUPS = AttributeInfoBuilder.build( PredefinedAttributes.GROUPS_NAME, String.class, EnumSet.of(Flags.MULTIVALUED));
+        builder.addAttributeInfo(GROUPS);
 
         return builder.build();
     }


### PR DESCRIPTION
This changes two elements of the schema __MEMBERS__ in the group objectclass and __GROUPS__ in the account objectclass to be returned by default. We found this necessary for membership changes to groups to propagate correctly. 