### PR TITLE
Handle nullable user attributes

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GoogleAppsConnector.java
@@ -1695,12 +1695,12 @@ public class GoogleAppsConnector implements Connector, CreateOp, DeleteOp, Schem
                     .getIsDelegatedAdmin()));
         }
         if (null == attributesToGet || attributesToGet.contains(LAST_LOGIN_TIME_ATTR)) {
-            builder.addAttribute(AttributeBuilder.build(LAST_LOGIN_TIME_ATTR, user
-                    .getLastLoginTime().toString()));
+            builder.addAttribute(AttributeBuilder.build(LAST_LOGIN_TIME_ATTR, 
+            null != user.getLastLoginTime() ? user.getLastLoginTime().toString() : null));
         }
         if (null == attributesToGet || attributesToGet.contains(CREATION_TIME_ATTR)) {
-            builder.addAttribute(AttributeBuilder.build(CREATION_TIME_ATTR, user.getCreationTime()
-                    .toString()));
+            builder.addAttribute(AttributeBuilder.build(CREATION_TIME_ATTR,
+            null != user.getCreationTime() ? user.getCreationTime().toString() : null));
         }
         if (null == attributesToGet || attributesToGet.contains(AGREED_TO_TERMS_ATTR)) {
             builder.addAttribute(AttributeBuilder.build(AGREED_TO_TERMS_ATTR, user


### PR DESCRIPTION
Faced the problem during the account provisioning - a newly created account has creationTime == null. Use it in some conditions by accessing shadow object directly, so further processing (cast to String) leads to NullPointerException. 
Added null checking for lastLogin time as well, to keep logic consistent.