### PR TITLE
Add object class descriptions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <artifactId>connector-parent</artifactId>
         <groupId>com.evolveum.polygon</groupId>
-        <version>1.5.0.0</version>
+        <version>1.5.3.0-SNAPSHOT</version>
         <relativePath/>
     </parent>
 

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GroupHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GroupHandler.java
@@ -185,7 +185,8 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(ObjectClass.GROUP_NAME);
-        builder.setDescription("Google Workspace group");
+        builder.setDescription("A Google Group used as an email distribution list and membership container. "
+                + "Group memberships are represented separately by the Member object class.");
         // email
         builder.addAttributeInfo(Name.INFO);
         builder.addAttributeInfo(AttributeInfoBuilder.build(NAME_ATTR));
@@ -217,7 +218,8 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(MEMBER.getObjectClassValue());
-        builder.setDescription("Google Workspace group membership");
+        builder.setDescription("A membership relationship linking a user, another group, or a customer domain "
+                + "to a Google Group. It includes the member type and role, such as MEMBER, MANAGER, or OWNER.");
         builder.addAttributeInfo(AttributeInfoBuilder.define(Name.NAME).setUpdateable(false)
                 .setCreateable(false)/* .setRequired(true) */.build());
 

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/GroupHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/GroupHandler.java
@@ -185,6 +185,7 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(ObjectClass.GROUP_NAME);
+        builder.setDescription("Google Workspace group");
         // email
         builder.addAttributeInfo(Name.INFO);
         builder.addAttributeInfo(AttributeInfoBuilder.build(NAME_ATTR));
@@ -216,6 +217,7 @@ public class GroupHandler implements FilterVisitor<Void, Directory.Groups.List> 
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(MEMBER.getObjectClassValue());
+        builder.setDescription("Google Workspace group membership");
         builder.addAttributeInfo(AttributeInfoBuilder.define(Name.NAME).setUpdateable(false)
                 .setCreateable(false)/* .setRequired(true) */.build());
 

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/LicenseAssignmentsHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/LicenseAssignmentsHandler.java
@@ -84,7 +84,8 @@ public class LicenseAssignmentsHandler {
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(LICENSE_ASSIGNMENT.getObjectClassValue());
-        builder.setDescription("Google Workspace product license assignment");
+        builder.setDescription("A relationship assigning a Google Workspace product SKU to a user. It connects "
+                + "the user, product, and SKU and can be used to assign, revoke, or change a license.");
         // productId
         builder.addAttributeInfo(AttributeInfoBuilder.define(PRODUCT_ID_ATTR).setRequired(true)
                 .build());

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/LicenseAssignmentsHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/LicenseAssignmentsHandler.java
@@ -84,6 +84,7 @@ public class LicenseAssignmentsHandler {
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(LICENSE_ASSIGNMENT.getObjectClassValue());
+        builder.setDescription("Google Workspace product license assignment");
         // productId
         builder.addAttributeInfo(AttributeInfoBuilder.define(PRODUCT_ID_ATTR).setRequired(true)
                 .build());

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/OrgunitsHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/OrgunitsHandler.java
@@ -87,7 +87,8 @@ public class OrgunitsHandler {
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(ORG_UNIT.getObjectClassValue());
-        builder.setDescription("Google Workspace organizational unit");
+        builder.setDescription("A node in the Google Workspace organizational hierarchy. Users assigned to it "
+                + "receive the services and settings configured for that organizational unit.");
         builder.setContainer(true);
         // primaryEmail
         builder.addAttributeInfo(Name.INFO);

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/OrgunitsHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/OrgunitsHandler.java
@@ -87,6 +87,7 @@ public class OrgunitsHandler {
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
         builder.setType(ORG_UNIT.getObjectClassValue());
+        builder.setDescription("Google Workspace organizational unit");
         builder.setContainer(true);
         // primaryEmail
         builder.addAttributeInfo(Name.INFO);

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/UserHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/UserHandler.java
@@ -425,6 +425,7 @@ public class UserHandler implements FilterVisitor<StringBuilder, Directory.Users
          */
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
+        builder.setDescription("Google Workspace user account");
 
         // primaryEmail
         builder.addAttributeInfo(Name.INFO);

--- a/src/main/java/com/evolveum/polygon/connector/googleapps/UserHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/googleapps/UserHandler.java
@@ -425,7 +425,9 @@ public class UserHandler implements FilterVisitor<StringBuilder, Directory.Users
          */
         // @formatter:on
         ObjectClassInfoBuilder builder = new ObjectClassInfoBuilder();
-        builder.setDescription("Google Workspace user account");
+        builder.setDescription("A user identity in the configured Google Workspace domain. "
+                + "Represents the user's sign-in account, profile, status, organizational unit, aliases, "
+                + "and contact information.");
 
         // primaryEmail
         builder.addAttributeInfo(Name.INFO);

--- a/src/test/java/com/evolveum/polygon/connector/googleapps/TestSchemaDescriptions.java
+++ b/src/test/java/com/evolveum/polygon/connector/googleapps/TestSchemaDescriptions.java
@@ -30,14 +30,22 @@ public class TestSchemaDescriptions {
     public void testObjectClassDescriptions() {
         Schema schema = new GoogleAppsConnector().schema();
 
-        assertDescription(schema, ObjectClass.ACCOUNT_NAME, "Google Workspace user account");
-        assertDescription(schema, ObjectClass.GROUP_NAME, "Google Workspace group");
+        assertDescription(schema, ObjectClass.ACCOUNT_NAME,
+                "A user identity in the configured Google Workspace domain. "
+                        + "Represents the user's sign-in account, profile, status, organizational unit, aliases, "
+                        + "and contact information.");
+        assertDescription(schema, ObjectClass.GROUP_NAME,
+                "A Google Group used as an email distribution list and membership container. "
+                        + "Group memberships are represented separately by the Member object class.");
         assertDescription(schema, GoogleAppsConnector.MEMBER.getObjectClassValue(),
-                "Google Workspace group membership");
+                "A membership relationship linking a user, another group, or a customer domain "
+                        + "to a Google Group. It includes the member type and role, such as MEMBER, MANAGER, or OWNER.");
         assertDescription(schema, GoogleAppsConnector.ORG_UNIT.getObjectClassValue(),
-                "Google Workspace organizational unit");
+                "A node in the Google Workspace organizational hierarchy. Users assigned to it "
+                        + "receive the services and settings configured for that organizational unit.");
         assertDescription(schema, GoogleAppsConnector.LICENSE_ASSIGNMENT.getObjectClassValue(),
-                "Google Workspace product license assignment");
+                "A relationship assigning a Google Workspace product SKU to a user. It connects "
+                        + "the user, product, and SKU and can be used to assign, revoke, or change a license.");
     }
 
     private static void assertDescription(Schema schema, String objectClassType, String expectedDescription) {

--- a/src/test/java/com/evolveum/polygon/connector/googleapps/TestSchemaDescriptions.java
+++ b/src/test/java/com/evolveum/polygon/connector/googleapps/TestSchemaDescriptions.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Evolveum
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.evolveum.polygon.connector.googleapps;
+
+import org.identityconnectors.framework.common.objects.ObjectClass;
+import org.identityconnectors.framework.common.objects.ObjectClassInfo;
+import org.identityconnectors.framework.common.objects.Schema;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertEquals;
+import static org.testng.AssertJUnit.assertNotNull;
+
+public class TestSchemaDescriptions {
+
+    @Test
+    public void testObjectClassDescriptions() {
+        Schema schema = new GoogleAppsConnector().schema();
+
+        assertDescription(schema, ObjectClass.ACCOUNT_NAME, "Google Workspace user account");
+        assertDescription(schema, ObjectClass.GROUP_NAME, "Google Workspace group");
+        assertDescription(schema, GoogleAppsConnector.MEMBER.getObjectClassValue(),
+                "Google Workspace group membership");
+        assertDescription(schema, GoogleAppsConnector.ORG_UNIT.getObjectClassValue(),
+                "Google Workspace organizational unit");
+        assertDescription(schema, GoogleAppsConnector.LICENSE_ASSIGNMENT.getObjectClassValue(),
+                "Google Workspace product license assignment");
+    }
+
+    private static void assertDescription(Schema schema, String objectClassType, String expectedDescription) {
+        ObjectClassInfo objectClassInfo = schema.findObjectClassInfo(objectClassType);
+        assertNotNull("Object class is missing: " + objectClassType, objectClassInfo);
+        assertEquals("Unexpected description for " + objectClassType,
+                expectedDescription, objectClassInfo.getDescription());
+    }
+}


### PR DESCRIPTION
## Summary

Add meaningful, relationship-aware Google Workspace object class descriptions to the ConnId schema so they provide useful context to administrators and AI-assisted analysis.

## Implementation

- Describe Google Workspace user accounts and the information they represent.
- Describe groups as email and membership containers.
- Describe group membership relationships, including member types and roles.
- Describe organizational units and their effect on user services and settings.
- Describe product license assignments and their user/product/SKU relationship.
- Update the connector parent to 1.5.3.0-SNAPSHOT for object class description support.

## Verification

- `mvn clean package` passed: 1 TestNG test, 0 failures, 0 errors.
- The schema test asserts the exact descriptions for all five object classes.
- Runtime inspection of `new GoogleAppsConnector().schema()` confirmed the five descriptions returned by the built connector.
- The branch connector was loaded into Docker midPoint 4.11 nightly; the full resource test succeeded and midPoint persisted all five descriptions in the generated resource schema.
- No live Google Workspace data operations were exercised; tenant credentials are not required to verify these static schema descriptions.

## Tracking

Story: https://support.evolveum.com/projects/connectors/work_packages/11625/activity

This is part of a coordinated change across the LDAP, Google Apps, Microsoft Graph API, SAP, and Zoom connectors.

## Related pull requests

- LDAP: https://github.com/Evolveum/connector-ldap/pull/43
- Google Apps: https://github.com/Evolveum/connector-googleapps/pull/20
- Microsoft Graph API: https://github.com/Evolveum/connector-microsoft-graph-api/pull/46
- SAP: https://github.com/Evolveum/connector-sap/pull/15
- Zoom: https://github.com/Evolveum/connector-zoom/pull/1
